### PR TITLE
Use VS version (it was hardcoded)

### DIFF
--- a/Conan.VisualStudio/Services/VcProjectService.cs
+++ b/Conan.VisualStudio/Services/VcProjectService.cs
@@ -136,12 +136,16 @@ namespace Conan.VisualStudio.Services
             string installPath = GetInstallationDirectoryImpl(settingsService, configuration);
             var VCCLCompilerTool = configuration.Tools.Item("VCCLCompilerTool");
 
+            string path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "msenv.dll");
+            System.Diagnostics.FileVersionInfo fvi = System.Diagnostics.FileVersionInfo.GetVersionInfo(path);
+            int verName = fvi.ProductMajorPart;
+
             return new ConanConfiguration
             {
                 Architecture = GetArchitecture(configuration.Platform.Name),
                 BuildType = GetBuildType(configuration.ConfigurationName),
                 CompilerToolset = toolset,
-                CompilerVersion = "15",
+                CompilerVersion = verName.ToString(),
                 InstallPath = installPath,
                 RuntimeLibrary = RuntimeLibraryToString(VCCLCompilerTool.RuntimeLibrary)
             };


### PR DESCRIPTION
@SSE4, I'm not sure if here we need some kind of try/catch or to handle any error (I get this snippet from [stackoverflow](https://stackoverflow.com/questions/11082436/detect-the-visual-studio-version-inside-a-vspackage/11097293#11097293) and there was a `if (File.Exists(path))`). If we cannot autodetect the version, there is nothing we can do right now... :/