### PR TITLE
Prepare for release 1.0.x

### DIFF
--- a/Conan.VisualStudio.Core/ConanConfiguration.cs
+++ b/Conan.VisualStudio.Core/ConanConfiguration.cs
@@ -11,11 +11,13 @@ namespace Conan.VisualStudio.Core
 
         public override string ToString()
         {
-            return $"Architecture: {Architecture}, " +
-                   $"build type: {BuildType}, " +
-                   $"compiler toolset: {CompilerToolset}, " +
-                   $"compiler version: {CompilerVersion}, " +
-                   $"runtime library: {RuntimeLibrary}";
+            string value = $"Architecture: {Architecture}, " +
+                           $"build type: {BuildType}, " +
+                           $"compiler toolset: {CompilerToolset}, " +
+                           $"compiler version: {CompilerVersion};";
+            if (RuntimeLibrary != null)
+                value += $", runtime library: {RuntimeLibrary}";
+            return value;
         }
     }
 }

--- a/Conan.VisualStudio.Core/ConanPathHelper.cs
+++ b/Conan.VisualStudio.Core/ConanPathHelper.cs
@@ -55,15 +55,14 @@ namespace Conan.VisualStudio.Core
         {
             while (path != null)
             {
-                if (File.Exists(Path.Combine(path, "conanfile.py"))
-                    || File.Exists(Path.Combine(path, "conanfile.txt")))
-                {
-                    break;
-                }
-
+                string conanfile_py = Path.Combine(path, "conanfile.py");
+                string conanfile_txt = Path.Combine(path, "conanfile.txt");
+                if (File.Exists(conanfile_py))
+                    return conanfile_py;
+                if (File.Exists(conanfile_txt))
+                    return conanfile_txt;
                 path = Directory.GetParent(path)?.FullName;
             }
-
             return path;
         }
 
@@ -71,5 +70,12 @@ namespace Conan.VisualStudio.Core
         {
             return GetNearestConanfilePath(path);
         });
+
+        public static string NormalizePath(string path)
+        {
+            return Path.GetFullPath(new Uri(path).LocalPath)
+                       .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                       .ToUpperInvariant();
+        }
     }
 }

--- a/Conan.VisualStudio.Core/ConanRunner.cs
+++ b/Conan.VisualStudio.Core/ConanRunner.cs
@@ -23,8 +23,6 @@ namespace Conan.VisualStudio.Core
         {
             string ProcessArgument(string name, string value) => $"-s {name}={Escape(value)}";
 
-            var path = Path.GetDirectoryName(project.Path);
-
             var arguments = string.Empty;
             if (_conanSettings != null)
             {
@@ -40,8 +38,11 @@ namespace Conan.VisualStudio.Core
                     ("build_type", configuration.BuildType),
                     ("compiler.toolset", configuration.CompilerToolset),
                     ("compiler.version", configuration.CompilerVersion),
-                    ("compiler.runtime", configuration.RuntimeLibrary),
                 };
+                if (configuration.RuntimeLibrary != null)
+                {
+                    settingValues = settingValues.Concat(new[] { ("compiler.runtime", configuration.RuntimeLibrary) }).ToArray();
+                }
                 string options = "";
                 if (build != ConanBuildType.none)
                 {
@@ -58,7 +59,7 @@ namespace Conan.VisualStudio.Core
                     var (key, value) = pair;
                     return ProcessArgument(key, value);
                 }));
-                arguments = $"install {Escape(path)} " +
+                arguments = $"install {Escape(project.Path)} " +
                             $"-g {generatorName} " +
                             $"--install-folder {Escape(configuration.InstallPath)} " +
                             $"{settings} {options}";
@@ -69,7 +70,7 @@ namespace Conan.VisualStudio.Core
                 FileName = _executablePath,
                 Arguments = arguments,
                 UseShellExecute = false,
-                WorkingDirectory = path,
+                WorkingDirectory = Path.GetDirectoryName(project.Path),
                 RedirectStandardOutput = true,
                 CreateNoWindow = true
             };

--- a/Conan.VisualStudio.Tests/Core/ConanPathHelperTests.cs
+++ b/Conan.VisualStudio.Tests/Core/ConanPathHelperTests.cs
@@ -61,11 +61,11 @@ namespace Conan.VisualStudio.Tests.Core
         {
             var dir = FileSystemUtils.CreateTempDirectory();
             var conanfile = FileSystemUtils.CreateTempFile(dir, "conanfile.txt");
-            Assert.AreEqual(dir, await ConanPathHelper.GetNearestConanfilePathAsync(dir));
+            Assert.AreEqual(Path.Combine(dir, "conanfile.txt"), await ConanPathHelper.GetNearestConanfilePathAsync(dir));
 
             File.Delete(conanfile);
             FileSystemUtils.CreateTempFile(dir, "conanfile.py");
-            Assert.AreEqual(dir, await ConanPathHelper.GetNearestConanfilePathAsync(dir));
+            Assert.AreEqual(Path.Combine(dir, "conanfile.py"), await ConanPathHelper.GetNearestConanfilePathAsync(dir));
         }
 
         [TestMethod]
@@ -76,18 +76,18 @@ namespace Conan.VisualStudio.Tests.Core
             Directory.CreateDirectory(subdir);
 
             FileSystemUtils.CreateTempFile(dir, "conanfile.txt");
-            Assert.AreEqual(dir, await ConanPathHelper.GetNearestConanfilePathAsync(subdir));
+            Assert.AreEqual(Path.Combine(dir, "conanfile.txt"), await ConanPathHelper.GetNearestConanfilePathAsync(subdir));
         }
-        [Ignore("Manual test only; leaves traces at the disk root")]
+
         [TestMethod]
         public async Task GetNearestConanfilePathWorksForDiskRootAsync()
         {
-            var dir = FileSystemUtils.CreateTempDirectory();
-            var root = Path.GetPathRoot(dir);
+            var root = FileSystemUtils.CreateTempDirectory();
+            var dir = Directory.CreateDirectory(Path.Combine(root, Path.GetRandomFileName())).FullName;
 
             FileSystemUtils.CreateTempFile(root, "conanfile.txt");
-            Assert.AreEqual(root, await ConanPathHelper.GetNearestConanfilePathAsync(dir));
-            Assert.AreEqual(root, await ConanPathHelper.GetNearestConanfilePathAsync(root));
+            Assert.AreEqual(Path.Combine(root, "conanfile.txt"), await ConanPathHelper.GetNearestConanfilePathAsync(dir));
+            Assert.AreEqual(Path.Combine(root, "conanfile.txt"), await ConanPathHelper.GetNearestConanfilePathAsync(root));
         }
     }
 }

--- a/Conan.VisualStudio/Conan.VisualStudio.csproj
+++ b/Conan.VisualStudio/Conan.VisualStudio.csproj
@@ -124,6 +124,10 @@
     <None Include="app.config" />
     <None Include="Key.snk" />
     <None Include="packages.config" />
+    <Content Include="Resources\LICENSE.md">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
       <Generator>VsixManifestGenerator</Generator>

--- a/Conan.VisualStudio/Resources/LICENSE.md
+++ b/Conan.VisualStudio/Resources/LICENSE.md
@@ -1,0 +1,23 @@
+MIT License
+
+Copyright (c) 2017 Bincrafters
+
+Copyright (c) 2019 JFrog LTD
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Conan.VisualStudio/Services/ConanService.cs
+++ b/Conan.VisualStudio/Services/ConanService.cs
@@ -37,6 +37,17 @@ namespace Conan.VisualStudio.Services
             string absPropFilePath = GetPropsFilePath(configuration);
             string relativePropFilePath = ConanPathHelper.GetRelativePath(configuration.project.ProjectDirectory, absPropFilePath);
 
+            IVCCollection tools = (IVCCollection)configuration.Tools;
+            if (tools != null)
+            {
+                VCLinkerTool ltool = (VCLinkerTool)tools.Item("VCLinkerTool");
+                if (ltool != null)
+                {
+                    string deps = ltool.AdditionalDependencies;
+                    ltool.AdditionalDependencies = deps.Replace("$(NOINHERIT)", "");
+                }
+            }
+
             foreach (VCPropertySheet sheet in configuration.PropertySheets)
             {
                 if (ConanPathHelper.NormalizePath(sheet.PropertySheetFile) == ConanPathHelper.NormalizePath(absPropFilePath))

--- a/Conan.VisualStudio/Services/SolutionEventsHandler.cs
+++ b/Conan.VisualStudio/Services/SolutionEventsHandler.cs
@@ -95,7 +95,8 @@ namespace Conan.VisualStudio.Services
                 RedirectStandardOutput = true,
                 CreateNoWindow = true
             };
-            System.Diagnostics.Process.Start(startInfo);
+            // TODO: Path to hardcoded MSBuild/15.0, make it conditional
+            // System.Diagnostics.Process.Start(startInfo);
         }
 
         public int OnAfterOpenProject(IVsHierarchy pHierarchy, int fAdded)

--- a/Conan.VisualStudio/Services/VcProjectService.cs
+++ b/Conan.VisualStudio/Services/VcProjectService.cs
@@ -52,7 +52,7 @@ namespace Conan.VisualStudio.Services
 
         public ConanProject ExtractConanProject(VCProject vcProject, ISettingsService settingsService)
         {
-            var projectPath = ConanPathHelper.GetNearestConanfilePath(vcProject.ProjectDirectory);
+            var projectPath = ConanPathHelper.GetNearestConanfilePath(vcProject.ProjectDirectory); // TODO: Instead of nearest, use the one added to the project (be explicit)
             if (projectPath == null)
             {
                 return null;

--- a/Conan.VisualStudio/Services/VcProjectService.cs
+++ b/Conan.VisualStudio/Services/VcProjectService.cs
@@ -155,7 +155,7 @@ namespace Conan.VisualStudio.Services
                 CompilerToolset = toolset,
                 CompilerVersion = ConanCompilerVersion(),
                 InstallPath = installPath,
-                RuntimeLibrary = RuntimeLibraryToString(VCCLCompilerTool.RuntimeLibrary)
+                RuntimeLibrary = VCCLCompilerTool != null ? RuntimeLibraryToString(VCCLCompilerTool.RuntimeLibrary) : null
             };
         }
 

--- a/Conan.VisualStudio/source.extension.vsixmanifest
+++ b/Conan.VisualStudio/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
         <DisplayName>Conan Extension for Visual Studio</DisplayName>
         <Description xml:space="preserve">Conan Extension for Visual Studio automates the use of the Conan C/C++ package manager for retrieving dependencies within Visual Studio projects.</Description>
         <MoreInfo>https://github.com/conan-io/conan-vs-extension</MoreInfo>
-        <License>..\LICENSE.md</License>
+        <License>Resources\LICENSE.md</License>
         <ReleaseNotes>https://github.com/conan-io/conan-vs-extension/blob/master/CHANGELOG.md</ReleaseNotes>
         <Icon>Resources\Icon.png</Icon>
         <PreviewImage>Resources\Preview.png</PreviewImage>

--- a/VisualStudio.OpenFolder/CMakeSettings.cs
+++ b/VisualStudio.OpenFolder/CMakeSettings.cs
@@ -1,3 +1,4 @@
+using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Runtime.Serialization;

--- a/VisualStudio.OpenFolder/CMakeSettingsEqualityComparer.cs
+++ b/VisualStudio.OpenFolder/CMakeSettingsEqualityComparer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/VisualStudio.OpenFolder/CppProperties.cs
+++ b/VisualStudio.OpenFolder/CppProperties.cs
@@ -1,3 +1,4 @@
+using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Runtime.Serialization;

--- a/VisualStudio.OpenFolder/CppPropertiesEqualityComparer.cs
+++ b/VisualStudio.OpenFolder/CppPropertiesEqualityComparer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/VisualStudio.OpenFolder/Default.cs
+++ b/VisualStudio.OpenFolder/Default.cs
@@ -1,3 +1,4 @@
+using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Runtime.Serialization;

--- a/VisualStudio.OpenFolder/DefaultEqualityComparer.cs
+++ b/VisualStudio.OpenFolder/DefaultEqualityComparer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/VisualStudio.OpenFolder/DefaultTask.cs
+++ b/VisualStudio.OpenFolder/DefaultTask.cs
@@ -1,3 +1,4 @@
+using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Runtime.Serialization;

--- a/VisualStudio.OpenFolder/DefaultTaskEqualityComparer.cs
+++ b/VisualStudio.OpenFolder/DefaultTaskEqualityComparer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/VisualStudio.OpenFolder/TasksVs.cs
+++ b/VisualStudio.OpenFolder/TasksVs.cs
@@ -1,3 +1,4 @@
+using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Runtime.Serialization;

--- a/VisualStudio.OpenFolder/TasksVsEqualityComparer.cs
+++ b/VisualStudio.OpenFolder/TasksVsEqualityComparer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 


### PR DESCRIPTION
Changes for release 1.0.x:
 * Error uninstalling the plugin (#67)
 * Visual Studio solution generated with CMake was not including _Additional Dependencies_ so Conan ones were not taken into account at all (#81)
 * `conanfile.py` or `conanfile.txt` are searched into all the directory tree (#80)
 * ...and more minor changes preparing the release.