### PR TITLE
Look for matching Conan profile in a config file for the running VS configuration

### DIFF
--- a/Conan.VisualStudio.Core/Conan.VisualStudio.Core.csproj
+++ b/Conan.VisualStudio.Core/Conan.VisualStudio.Core.csproj
@@ -39,6 +39,9 @@
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/Conan.VisualStudio.Core/Conan.VisualStudio.Core.csproj
+++ b/Conan.VisualStudio.Core/Conan.VisualStudio.Core.csproj
@@ -60,6 +60,7 @@
     <Compile Include="ConanProject.cs" />
     <Compile Include="ConanRunner.cs" />
     <Compile Include="ConanSettings.cs" />
+    <Compile Include="IErrorListService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Conan.VisualStudio.Core/ConanConfiguration.cs
+++ b/Conan.VisualStudio.Core/ConanConfiguration.cs
@@ -2,6 +2,7 @@ namespace Conan.VisualStudio.Core
 {
     public class ConanConfiguration
     {
+        public string VSName { get; set; }
         public string Architecture { get; set; }
         public string BuildType { get; set; }
         public string CompilerToolset { get; set; }

--- a/Conan.VisualStudio.Core/ConanPathHelper.cs
+++ b/Conan.VisualStudio.Core/ConanPathHelper.cs
@@ -66,6 +66,21 @@ namespace Conan.VisualStudio.Core
             return path;
         }
 
+        /// <summary>
+        /// Searches for conan.config.json in the directory or any of its' parent paths.
+        /// </summary>
+        /// <returns>Path to the nearest conan.config.json file</returns>
+        public static string GetNearestConanConfig(string path)
+        {
+            while (path != null)
+            {
+                string conan_config = Path.Combine(path, "conan.config.json");
+                if (File.Exists(conan_config)) return conan_config;
+                path = Directory.GetParent(path)?.FullName;
+            }
+            return path;
+        }
+
         public static async Task<string> GetNearestConanfilePathAsync(string path) => await Task.Run(() =>
         {
             return GetNearestConanfilePath(path);

--- a/Conan.VisualStudio.Core/ConanProject.cs
+++ b/Conan.VisualStudio.Core/ConanProject.cs
@@ -1,11 +1,31 @@
 using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json.Linq;
+using System;
 
 namespace Conan.VisualStudio.Core
 {
     public class ConanProject
     {
         public string Path { get; set; }
-
+        public string ConfigFile { get; set; }
         public List<ConanConfiguration> Configurations { get; } = new List<ConanConfiguration>();
+
+        public string getProfile(ConanConfiguration configuration)
+        {
+            if (!File.Exists(ConfigFile)) return null;
+            try
+            {
+                JObject jObject = JObject.Parse(File.ReadAllText(ConfigFile));
+                var configs = jObject["configurations"].ToObject<Dictionary<string, string>>();
+                configs.TryGetValue(configuration.VSName, out string conanProfile);
+                return conanProfile;
+            }
+            catch (Exception)
+            {
+                // TODO: Check the error and log to user
+                return null;
+            }
+        }
     }
 }

--- a/Conan.VisualStudio.Core/ConanProject.cs
+++ b/Conan.VisualStudio.Core/ConanProject.cs
@@ -11,7 +11,7 @@ namespace Conan.VisualStudio.Core
         public string ConfigFile { get; set; }
         public List<ConanConfiguration> Configurations { get; } = new List<ConanConfiguration>();
 
-        public string getProfile(ConanConfiguration configuration)
+        public string getProfile(ConanConfiguration configuration, Core.IErrorListService errorListService)
         {
             if (!File.Exists(ConfigFile)) return null;
             try
@@ -19,11 +19,16 @@ namespace Conan.VisualStudio.Core
                 JObject jObject = JObject.Parse(File.ReadAllText(ConfigFile));
                 var configs = jObject["configurations"].ToObject<Dictionary<string, string>>();
                 configs.TryGetValue(configuration.VSName, out string conanProfile);
+                if (conanProfile == null)
+                {
+                    errorListService.WriteWarning($"File for Conan configuration found at '{ConfigFile}'," +
+                        $" but no profile declared for VS configuration '{configuration.VSName}'");
+                }
                 return conanProfile;
             }
             catch (Exception)
             {
-                // TODO: Check the error and log to user
+                errorListService.WriteError($"Error parsing Conan configuration from file '{ConfigFile}'");
                 return null;
             }
         }

--- a/Conan.VisualStudio.Core/ConanRunner.cs
+++ b/Conan.VisualStudio.Core/ConanRunner.cs
@@ -29,10 +29,22 @@ namespace Conan.VisualStudio.Core
             if (profile != null)
             {
                 string generatorName = generator.ToString();
+                string options = "";
+                if (build != ConanBuildType.none)
+                {
+                    options += " --build " + build.ToString();
+                }
+                if (update)
+                {
+                    options += " --update";
+                }
+
                 arguments = $"install {Escape(project.Path)} " +
                             $"-g {generatorName} " +
                             $"--install-folder {Escape(configuration.InstallPath)} " +
-                            $"--profile {Escape(profile)}";
+                            $"--profile {Escape(profile)}" +
+                            $"{options}";
+
             }
             else if (_conanSettings != null)
             {

--- a/Conan.VisualStudio.Core/ConanRunner.cs
+++ b/Conan.VisualStudio.Core/ConanRunner.cs
@@ -32,7 +32,7 @@ namespace Conan.VisualStudio.Core
                 arguments = $"install {Escape(project.Path)} " +
                             $"-g {generatorName} " +
                             $"--install-folder {Escape(configuration.InstallPath)} " +
-                            $"--profile {profile}";
+                            $"--profile {Escape(profile)}";
             }
             else if (_conanSettings != null)
             {

--- a/Conan.VisualStudio.Core/ConanRunner.cs
+++ b/Conan.VisualStudio.Core/ConanRunner.cs
@@ -19,13 +19,13 @@ namespace Conan.VisualStudio.Core
         private string Escape(string arg) =>
             arg.Contains(" ") ? $"\"{arg}\"" : arg;
 
-        public Task<Process> Install(ConanProject project, ConanConfiguration configuration, ConanGeneratorType generator, ConanBuildType build, bool update)
+        public Task<Process> Install(ConanProject project, ConanConfiguration configuration, ConanGeneratorType generator, ConanBuildType build, bool update, Core.IErrorListService errorListService)
         {
             string ProcessArgument(string name, string value) => $"-s {name}={Escape(value)}";
 
             var arguments = string.Empty;
 
-            string profile = project.getProfile(configuration);
+            string profile = project.getProfile(configuration, errorListService);
             if (profile != null)
             {
                 string generatorName = generator.ToString();

--- a/Conan.VisualStudio.Core/ConanRunner.cs
+++ b/Conan.VisualStudio.Core/ConanRunner.cs
@@ -24,7 +24,17 @@ namespace Conan.VisualStudio.Core
             string ProcessArgument(string name, string value) => $"-s {name}={Escape(value)}";
 
             var arguments = string.Empty;
-            if (_conanSettings != null)
+
+            string profile = project.getProfile(configuration);
+            if (profile != null)
+            {
+                string generatorName = generator.ToString();
+                arguments = $"install {Escape(project.Path)} " +
+                            $"-g {generatorName} " +
+                            $"--install-folder {Escape(configuration.InstallPath)} " +
+                            $"--profile {profile}";
+            }
+            else if (_conanSettings != null)
             {
                 var installConfig = _conanSettings.ConanCommands.FirstOrDefault(c => c.Name.Equals("install"));
                 arguments = installConfig.Args;

--- a/Conan.VisualStudio.Core/IErrorListService.cs
+++ b/Conan.VisualStudio.Core/IErrorListService.cs
@@ -1,4 +1,4 @@
-namespace Conan.VisualStudio.Services
+namespace Conan.VisualStudio.Core
 {
     public interface IErrorListService
     {

--- a/Conan.VisualStudio.Core/packages.config
+++ b/Conan.VisualStudio.Core/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
 </packages>

--- a/Conan.VisualStudio.Examples/ConanConfigExample/ConanConfigExample.sln
+++ b/Conan.VisualStudio.Examples/ConanConfigExample/ConanConfigExample.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29009.5
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ConanConfigExample", "ConanConfigExample\ConanConfigExample.vcxproj", "{D7500D23-BA43-49FD-B62D-7264AE5B018D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D7500D23-BA43-49FD-B62D-7264AE5B018D}.Debug|x64.ActiveCfg = Debug|x64
+		{D7500D23-BA43-49FD-B62D-7264AE5B018D}.Debug|x64.Build.0 = Debug|x64
+		{D7500D23-BA43-49FD-B62D-7264AE5B018D}.Debug|x86.ActiveCfg = Debug|Win32
+		{D7500D23-BA43-49FD-B62D-7264AE5B018D}.Debug|x86.Build.0 = Debug|Win32
+		{D7500D23-BA43-49FD-B62D-7264AE5B018D}.Release|x64.ActiveCfg = Release|x64
+		{D7500D23-BA43-49FD-B62D-7264AE5B018D}.Release|x64.Build.0 = Release|x64
+		{D7500D23-BA43-49FD-B62D-7264AE5B018D}.Release|x86.ActiveCfg = Release|Win32
+		{D7500D23-BA43-49FD-B62D-7264AE5B018D}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {525DB941-697F-4CCC-B327-0AA5FC7119D7}
+	EndGlobalSection
+EndGlobal

--- a/Conan.VisualStudio.Examples/ConanConfigExample/ConanConfigExample.sln
+++ b/Conan.VisualStudio.Examples/ConanConfigExample/ConanConfigExample.sln
@@ -7,12 +7,18 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ConanConfigExample", "Conan
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		CustomDebug|x64 = CustomDebug|x64
+		CustomDebug|x86 = CustomDebug|x86
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D7500D23-BA43-49FD-B62D-7264AE5B018D}.CustomDebug|x64.ActiveCfg = CustomDebug|x64
+		{D7500D23-BA43-49FD-B62D-7264AE5B018D}.CustomDebug|x64.Build.0 = CustomDebug|x64
+		{D7500D23-BA43-49FD-B62D-7264AE5B018D}.CustomDebug|x86.ActiveCfg = CustomDebug|Win32
+		{D7500D23-BA43-49FD-B62D-7264AE5B018D}.CustomDebug|x86.Build.0 = CustomDebug|Win32
 		{D7500D23-BA43-49FD-B62D-7264AE5B018D}.Debug|x64.ActiveCfg = Debug|x64
 		{D7500D23-BA43-49FD-B62D-7264AE5B018D}.Debug|x64.Build.0 = Debug|x64
 		{D7500D23-BA43-49FD-B62D-7264AE5B018D}.Debug|x86.ActiveCfg = Debug|Win32

--- a/Conan.VisualStudio.Examples/ConanConfigExample/ConanConfigExample/ConanConfigExample.cpp
+++ b/Conan.VisualStudio.Examples/ConanConfigExample/ConanConfigExample/ConanConfigExample.cpp
@@ -1,20 +1,8 @@
-// ConanConfigExample.cpp : This file contains the 'main' function. Program execution begins and ends there.
-//
-
 #include <iostream>
+#include <fmt/format.h>
+#include <fmt/printf.h>
 
 int main()
 {
-    std::cout << "Hello World!\n";
+    fmt::printf("Hello, %s!", "world");
 }
-
-// Run program: Ctrl + F5 or Debug > Start Without Debugging menu
-// Debug program: F5 or Debug > Start Debugging menu
-
-// Tips for Getting Started: 
-//   1. Use the Solution Explorer window to add/manage files
-//   2. Use the Team Explorer window to connect to source control
-//   3. Use the Output window to see build output and other messages
-//   4. Use the Error List window to view errors
-//   5. Go to Project > Add New Item to create new code files, or Project > Add Existing Item to add existing code files to the project
-//   6. In the future, to open this project again, go to File > Open > Project and select the .sln file

--- a/Conan.VisualStudio.Examples/ConanConfigExample/ConanConfigExample/ConanConfigExample.cpp
+++ b/Conan.VisualStudio.Examples/ConanConfigExample/ConanConfigExample/ConanConfigExample.cpp
@@ -4,5 +4,10 @@
 
 int main()
 {
-    fmt::printf("Hello, %s!", "world");
+    fmt::printf("Using fmt version '%d'\n", FMT_VERSION);
+    #ifdef FMT_STRING_ALIAS
+        // The CustomDebug configuration is mapped to the profile 'custom_config.profile'
+        //  where we are setting the value of the option 'fmt:with_fmt_alias=True'
+        fmt::printf("Using FMT_STRING_ALIAS\n");
+    #endif
 }

--- a/Conan.VisualStudio.Examples/ConanConfigExample/ConanConfigExample/ConanConfigExample.cpp
+++ b/Conan.VisualStudio.Examples/ConanConfigExample/ConanConfigExample/ConanConfigExample.cpp
@@ -1,0 +1,20 @@
+// ConanConfigExample.cpp : This file contains the 'main' function. Program execution begins and ends there.
+//
+
+#include <iostream>
+
+int main()
+{
+    std::cout << "Hello World!\n";
+}
+
+// Run program: Ctrl + F5 or Debug > Start Without Debugging menu
+// Debug program: F5 or Debug > Start Debugging menu
+
+// Tips for Getting Started: 
+//   1. Use the Solution Explorer window to add/manage files
+//   2. Use the Team Explorer window to connect to source control
+//   3. Use the Output window to see build output and other messages
+//   4. Use the Error List window to view errors
+//   5. Go to Project > Add New Item to create new code files, or Project > Add Existing Item to add existing code files to the project
+//   6. In the future, to open this project again, go to File > Open > Project and select the .sln file

--- a/Conan.VisualStudio.Examples/ConanConfigExample/ConanConfigExample/ConanConfigExample.vcxproj
+++ b/Conan.VisualStudio.Examples/ConanConfigExample/ConanConfigExample/ConanConfigExample.vcxproj
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <ProjectGuid>{D7500D23-BA43-49FD-B62D-7264AE5B018D}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>ConanConfigExample</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="ConanConfigExample.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Conan.VisualStudio.Examples/ConanConfigExample/ConanConfigExample/ConanConfigExample.vcxproj
+++ b/Conan.VisualStudio.Examples/ConanConfigExample/ConanConfigExample/ConanConfigExample.vcxproj
@@ -153,6 +153,12 @@
   <ItemGroup>
     <ClCompile Include="ConanConfigExample.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <Text Include="conanfile.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\conan.config.json" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/Conan.VisualStudio.Examples/ConanConfigExample/ConanConfigExample/ConanConfigExample.vcxproj
+++ b/Conan.VisualStudio.Examples/ConanConfigExample/ConanConfigExample/ConanConfigExample.vcxproj
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="CustomDebug|Win32">
+      <Configuration>CustomDebug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="CustomDebug|x64">
+      <Configuration>CustomDebug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
@@ -32,6 +40,12 @@
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='CustomDebug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -40,6 +54,12 @@
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='CustomDebug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
@@ -57,23 +77,20 @@
   </ImportGroup>
   <ImportGroup Label="Shared">
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='CustomDebug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='CustomDebug|x64'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -97,6 +114,21 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='CustomDebug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PrecompiledHeader>
@@ -105,6 +137,21 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='CustomDebug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;CUSTOM_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
@@ -158,6 +205,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="..\conan.config.json" />
+    <None Include="custom_config.profile" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Conan.VisualStudio.Examples/ConanConfigExample/ConanConfigExample/ConanConfigExample.vcxproj.filters
+++ b/Conan.VisualStudio.Examples/ConanConfigExample/ConanConfigExample/ConanConfigExample.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="ConanConfigExample.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/Conan.VisualStudio.Examples/ConanConfigExample/ConanConfigExample/ConanConfigExample.vcxproj.filters
+++ b/Conan.VisualStudio.Examples/ConanConfigExample/ConanConfigExample/ConanConfigExample.vcxproj.filters
@@ -24,5 +24,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="..\conan.config.json" />
+    <None Include="custom_config.profile" />
   </ItemGroup>
 </Project>

--- a/Conan.VisualStudio.Examples/ConanConfigExample/ConanConfigExample/ConanConfigExample.vcxproj.filters
+++ b/Conan.VisualStudio.Examples/ConanConfigExample/ConanConfigExample/ConanConfigExample.vcxproj.filters
@@ -19,4 +19,10 @@
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <Text Include="conanfile.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\conan.config.json" />
+  </ItemGroup>
 </Project>

--- a/Conan.VisualStudio.Examples/ConanConfigExample/ConanConfigExample/conanfile.txt
+++ b/Conan.VisualStudio.Examples/ConanConfigExample/ConanConfigExample/conanfile.txt
@@ -1,0 +1,5 @@
+[requires]
+fmt/5.3.0@bincrafters/stable
+
+[generators]
+visual_studio

--- a/Conan.VisualStudio.Examples/ConanConfigExample/ConanConfigExample/custom_config.profile
+++ b/Conan.VisualStudio.Examples/ConanConfigExample/ConanConfigExample/custom_config.profile
@@ -1,0 +1,11 @@
+[settings]
+os="Windows"
+arch="x86_64"
+build_type="Debug"
+compiler=Visual Studio
+compiler.version="16"
+compiler.toolset="v142"
+compiler.runtime="MDd"
+
+[options]
+fmt:with_fmt_alias=True

--- a/Conan.VisualStudio.Examples/ConanConfigExample/conan.config.json
+++ b/Conan.VisualStudio.Examples/ConanConfigExample/conan.config.json
@@ -1,0 +1,6 @@
+{
+    "configurations": {
+        "Release|x644": "default - Copy",
+        "Debug|x64": "C:/myprofile"
+    }
+}

--- a/Conan.VisualStudio.Examples/ConanConfigExample/conan.config.json
+++ b/Conan.VisualStudio.Examples/ConanConfigExample/conan.config.json
@@ -1,6 +1,5 @@
 {
     "configurations": {
-        "Release|x644": "default - Copy",
-        "Debug|x64": "C:/myprofile"
+        "CustomDebug|x64": "custom_config.profile"
     }
 }

--- a/Conan.VisualStudio.Tests/packages.config
+++ b/Conan.VisualStudio.Tests/packages.config
@@ -30,7 +30,7 @@
   <package id="Moq" version="4.8.0" targetFramework="net47" />
   <package id="MSTest.TestAdapter" version="1.4.0" targetFramework="net47" />
   <package id="MSTest.TestFramework" version="1.4.0" targetFramework="net47" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net47" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net461" />
   <package id="StreamJsonRpc" version="1.3.23" targetFramework="net47" />
   <package id="System.Threading.Tasks.Extensions" version="4.4.0" targetFramework="net47" />
 </packages>

--- a/Conan.VisualStudio/Conan.VisualStudio.csproj
+++ b/Conan.VisualStudio/Conan.VisualStudio.csproj
@@ -87,7 +87,6 @@
     <Compile Include="Services\ConanService.cs" />
     <Compile Include="Services\ErrorListService.cs" />
     <Compile Include="Services\IConanService.cs" />
-    <Compile Include="Services\IErrorListService.cs" />
     <Compile Include="Services\InfoBarEventsHandler.cs" />
     <Compile Include="Services\InfobarService.cs" />
     <Compile Include="Services\SolutionEventsHandler.cs" />

--- a/Conan.VisualStudio/Menu/AddConanDependsConanfile.cs
+++ b/Conan.VisualStudio/Menu/AddConanDependsConanfile.cs
@@ -15,14 +15,14 @@ namespace Conan.VisualStudio.Menu
     {
         protected override int CommandId => PackageIds.AddConanDependsConanfileId;
 
-        private readonly IErrorListService _errorListService;
+        private readonly Core.IErrorListService _errorListService;
         private readonly IVcProjectService _vcProjectService;
         private readonly IConanService _conanService;
         private readonly DTE2 _dte2;
 
         public AddConanDependsConanfile(
             IMenuCommandService commandService,
-            IErrorListService errorListService,
+            Core.IErrorListService errorListService,
             IVcProjectService vcProjectService,
             IConanService conanService) : base(commandService, errorListService)
         {

--- a/Conan.VisualStudio/Menu/AddConanDependsProject.cs
+++ b/Conan.VisualStudio/Menu/AddConanDependsProject.cs
@@ -9,13 +9,13 @@ namespace Conan.VisualStudio.Menu
     {
         protected override int CommandId => PackageIds.AddConanDependsProjectId;
 
-        private readonly IErrorListService _errorListService;
+        private readonly Core.IErrorListService _errorListService;
         private readonly IVcProjectService _vcProjectService;
         private readonly IConanService _conanService;
 
         public AddConanDependsProject(
             IMenuCommandService commandService,
-            IErrorListService errorListService,
+            Core.IErrorListService errorListService,
             IVcProjectService vcProjectService,
             IConanService conanService) : base(commandService, errorListService)
         {

--- a/Conan.VisualStudio/Menu/AddConanDependsSolution.cs
+++ b/Conan.VisualStudio/Menu/AddConanDependsSolution.cs
@@ -16,12 +16,12 @@ namespace Conan.VisualStudio.Menu
         protected override int CommandId => PackageIds.AddConanDependsSolutiontId;
 
         private readonly IVcProjectService _vcProjectService;
-        private readonly IErrorListService _errorListService;
+        private readonly Core.IErrorListService _errorListService;
         private readonly IConanService _conanService;
 
         public AddConanDependsSolution(
             IMenuCommandService commandService,
-            IErrorListService errorListService,
+            Core.IErrorListService errorListService,
             IVcProjectService vcProjectService,
             IConanService conanService) : base(commandService, errorListService)
         {

--- a/Conan.VisualStudio/Menu/ConanOptions.cs
+++ b/Conan.VisualStudio/Menu/ConanOptions.cs
@@ -16,7 +16,7 @@ namespace Conan.VisualStudio.Menu
 
         public ConanOptions(
             IMenuCommandService commandService,
-            IErrorListService errorListService,
+            Core.IErrorListService errorListService,
             OptionsDelegate optionsDelegate)
             : base(commandService, errorListService)
         {

--- a/Conan.VisualStudio/Menu/MenuCommandBase.cs
+++ b/Conan.VisualStudio/Menu/MenuCommandBase.cs
@@ -8,12 +8,12 @@ namespace Conan.VisualStudio.Menu
     /// <summary>Base class for a menu command.</summary>
     internal abstract class MenuCommandBase
     {
-        private readonly IErrorListService _errorListService;
+        private readonly Core.IErrorListService _errorListService;
         private readonly OleMenuCommand _menuCommand;
 
         protected abstract int CommandId { get; }
 
-        public MenuCommandBase(IMenuCommandService commandService, IErrorListService errorListService)
+        public MenuCommandBase(IMenuCommandService commandService, Core.IErrorListService errorListService)
         {
             _errorListService = errorListService;
             var menuCommandId = new CommandID(PackageGuids.guidVSConanPackageCmdSet, CommandId);

--- a/Conan.VisualStudio/Services/ConanService.cs
+++ b/Conan.VisualStudio/Services/ConanService.cs
@@ -10,10 +10,10 @@ namespace Conan.VisualStudio.Services
     internal class ConanService : IConanService
     {
         private readonly ISettingsService _settingsService;
-        private readonly IErrorListService _errorListService;
+        private readonly Core.IErrorListService _errorListService;
         private readonly IVcProjectService _vcProjectService;
 
-        public ConanService(ISettingsService settingsService, IErrorListService errorListService, IVcProjectService vcProjectService)
+        public ConanService(ISettingsService settingsService, Core.IErrorListService errorListService, IVcProjectService vcProjectService)
         {
             _settingsService = settingsService;
             _errorListService = errorListService;
@@ -116,7 +116,8 @@ namespace Conan.VisualStudio.Services
                     ConanGeneratorType generator = _settingsService.GetConanGenerator();
                     ConanBuildType build = _settingsService.GetConanBuild();
                     bool update = _settingsService.GetConanUpdate();
-                    var process = await conan.Install(project, configuration, generator, build, update);
+                   
+                    var process = await conan.Install(project, configuration, generator, build, update, _errorListService);
 
                     string message = $"[Conan.VisualStudio] Calling process '{process.StartInfo.FileName}' " +
                         $"with arguments '{process.StartInfo.Arguments}'";

--- a/Conan.VisualStudio/Services/ErrorListService.cs
+++ b/Conan.VisualStudio/Services/ErrorListService.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TextManager.Interop;
 
 namespace Conan.VisualStudio.Services
 {
-    public class ErrorListService : IServiceProvider, IErrorListService
+    public class ErrorListService : IServiceProvider, Core.IErrorListService
     {
         private static readonly Guid ErrorListProviderGuid = new Guid("{8F355B84-E2DE-4FE9-8482-BF7FC11A6059}");
 

--- a/Conan.VisualStudio/Services/SolutionEventsHandler.cs
+++ b/Conan.VisualStudio/Services/SolutionEventsHandler.cs
@@ -53,9 +53,11 @@ namespace Conan.VisualStudio.Services
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
+            string projectConanConfig = ConanPathHelper.GetNearestConanConfig(project.FileName);
             var conanProject = new ConanProject
             {
-                Path = project.FileName
+                Path = project.FileName,
+                ConfigFile = projectConanConfig
             };
 
             await TaskScheduler.Default;

--- a/Conan.VisualStudio/Services/VcProjectService.cs
+++ b/Conan.VisualStudio/Services/VcProjectService.cs
@@ -57,9 +57,12 @@ namespace Conan.VisualStudio.Services
             {
                 return null;
             }
+
+            string projectConanConfig = ConanPathHelper.GetNearestConanConfig(vcProject.ProjectDirectory);
             var project = new ConanProject
             {
                 Path = projectPath,
+                ConfigFile = projectConanConfig
             };
 
             if (settingsService != null && settingsService.GetConanInstallOnlyActiveConfiguration())
@@ -150,6 +153,7 @@ namespace Conan.VisualStudio.Services
 
             return new ConanConfiguration
             {
+                VSName = configuration.Name,
                 Architecture = GetArchitecture(configuration.Platform.Name),
                 BuildType = GetBuildType(configuration.ConfigurationName),
                 CompilerToolset = toolset,

--- a/Conan.VisualStudio/VSConanPackage.cs
+++ b/Conan.VisualStudio/VSConanPackage.cs
@@ -45,7 +45,7 @@ namespace Conan.VisualStudio
         private IVsSolutionBuildManager3 _solutionBuildManager;
         private ProjectItemsEvents _projectItemEvents;
         private DocumentEvents _documentEvents;
-        private IErrorListService _errorListService;
+        private Core.IErrorListService _errorListService;
 
         /// <summary>
         /// Initialization of the package; this method is called right after the package is sited, so this is the place


### PR DESCRIPTION
The extension looks into a file `conan.config.json` for a Conan profile name associated with the Visual Studio configuration. This file is searched first in the same directory as the VS Project, and then in any parent directory.

The format for this file (it should be extensible in the future):

```json
{  
   "configurations": {  
      "Release|Win32": "release_win32",
      "Debug|x64": "debug_x64",
      "Release|Win64": "C:/conan/profiles/release_win64"
   }
}
```

Under the `"configurations"` key there is a dictionary with the correspondence between the VS configuration (key, on the left) and a Conan profile (value, on the right). To take into account:
 * VS creates the configuration name joining with a `|` character the name of the `Configuration` and the `Platform`.
![image](https://user-images.githubusercontent.com/1406456/60172298-ad895980-980c-11e9-85dc-4da9a83235b2.png)
 * For Conan profiles, the value declared will be used verbatim for the `--profile` argument in the `conan install` command, and rules related to profile lookup applies.


closes #88
related to #5 (first iteration)