### PR TITLE
Add very basic docs

### DIFF
--- a/Conan.VisualStudio.Examples/README.md
+++ b/Conan.VisualStudio.Examples/README.md
@@ -1,0 +1,4 @@
+## ExampleCLI
+
+This example has a `conanfile.txt` with a dependency on the popular formatting library `fmt`. When the project is first opened, Visual Studio is unable to find the `fmt` project dependency. The extension should immediately run however, after it the `fmt` headers should be found by the compiler, and the `lib` files should be found by the linker successfully.
+

--- a/README.md
+++ b/README.md
@@ -51,16 +51,13 @@ It will output the `.vsix` file to:
 From there, you can share and/or install the `.vsix` file as desired. Here is a decent [blog post about working with `.vsix` files manually](https://weblog.west-wind.com/posts/2016/Mar/01/Registering-and-Unregistering-a-VSIX-Extension-from-the-Command-Line#Installing)
 
 #### Using the Extension with Changes
-Once you have the Visual Studio environment with the modified extension loaded, or have installed the extension from the `.vsix` file, you can test it by opening the example project:
+Once you have the Visual Studio environment with the modified extension loaded, or have installed the extension from the `.vsix` file, you can test it by opening one of the examples in the [`Conan.VisualStudio.Examples` directory](Conan.VisualStudio.Examples/):
 
-	Conan.VisualStudio.Examples/ExampleCLI/ExampleCLI.sln
 
-This example has a `conanfile.txt` with a dependency on the popular formatting library `fmt`. When the project is first opened, Visual Studio is unable to find the `fmt` project dependency. The extension should immediately run however, and Visual Studio should give you a toolbar dropdown message offering to refresh the project. After refreshing, the `fmt` headers should be found by the compiler, and the `lib` files should be found by the linker successfully.  
+Acknowledgements
+----------------
 
-Changelog
----------
-
-This extension started was started by community members like @sboullema, @SSE4, @ForNeVer and @solvingj, thanks to
+This extension was started by community members like @sboullema, @SSE4, @ForNeVer and @solvingj, thanks to
 them the first version of the extension was given birth and now [the Conan team is supporting it and pusing it
 forward](https://blog.conan.io/2019/06/17/Conan-extension-for-Visual-Studio.html). We still receive very valuable
 contributions from the community and we hope to continue to receive them.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,18 @@ conan-vs-extension
 
 An extension for Visual Studio 2017/2019 which automates the use of [the Conan C/C++ package manager](https://conan.io/) for retrieving dependencies within Visual Studio projects.  
 
-Extension Installation
------------------------
-The extension will soon be published to the Visual Studio marketplace. Please find it there to install. 
+Installation
+------------
+Use the Extension Manager inside Visual Studio, or visit
+the [Visual Studio marketplace](https://marketplace.visualstudio.com/items?itemName=conan-io.conan-vs-extension)
+to download it.
+
+Documentation
+-------------
+
+Visit the [documentation](https://github.com/conan-io/conan-vs-extension/tree/master/docs) for details
+on how to use the Conan Extension for Visual Studio.
+
 
 Extension Usage
 -----------------------
@@ -26,11 +35,11 @@ In order to be able to build extension from the source, you need Visual Studio 2
 If you want to build the extension yourself and test it locally (perhaps because you are making changes for a PR), you can currently test the extension one of two ways:  Debug Mode and Local VSIX Installation.
 
 #### Debug Mode  
-Most likely, you should just run your changes in debug mode.  Open the `Conan.VisualStudio.sln` file using the Visual Studio 2017 or 2019 and  `Run` the project. It will create an isolated Visual Studio environment and load the extension.  
+Most likely, you should just run your changes in debug mode. Open the `Conan.VisualStudio.sln` file using the Visual Studio 2017 or 2019 and `Run` the project. It will create an isolated Visual Studio environment and load the extension.  
 *Note: This can take up to a minute or two.*
 
 #### Local VSIX Installation  
-Alternatively, you may want to build the VSIX and share with a few other developers or something.  In that case, just "Build" the `Release` configuration of project in Visual Studio.  You can build from a Developer Command prompt with this command: 
+Alternatively, you may want to build the VSIX and share with a few other developers. In that case, just "Build" the `Release` configuration of project in Visual Studio. You can build from a Developer Command prompt with this command: 
 
 	$ msbuild /p:Configuration=Release
 
@@ -42,25 +51,20 @@ It will output the `.vsix` file to:
 From there, you can share and/or install the `.vsix` file as desired. Here is a decent [blog post about working with `.vsix` files manually](https://weblog.west-wind.com/posts/2016/Mar/01/Registering-and-Unregistering-a-VSIX-Extension-from-the-Command-Line#Installing)
 
 #### Using the Extension with Changes
-
 Once you have the Visual Studio environment with the modified extension loaded, or have installed the extension from the `.vsix` file, you can test it by opening the example project:
 
 	Conan.VisualStudio.Examples/ExampleCLI/ExampleCLI.sln
 
-This example has a `conanfile.txt` with a dependency on the popular formatting library `fmt`.  When the project is first opened, Visual Studio is unable to find the `fmt` project dependency.  The extension should immediately run however, and Visual Studio should give you a toolbar dropdown message offering to refresh the project.  After refreshing, the `fmt` headers should be found by the compiler, and the `lib` files should be found by the linker successfully.  
+This example has a `conanfile.txt` with a dependency on the popular formatting library `fmt`. When the project is first opened, Visual Studio is unable to find the `fmt` project dependency. The extension should immediately run however, and Visual Studio should give you a toolbar dropdown message offering to refresh the project. After refreshing, the `fmt` headers should be found by the compiler, and the `lib` files should be found by the linker successfully.  
 
+Changelog
+---------
 
-Update 03-14-2019
-------------------
-Thanks to @sboulema and @SSE4, the extension now provides the minimum required functionality for basic use and initial testing. 
+This extension started was started by community members like @sboullema, @SSE4, @ForNeVer and @solvingj, thanks to
+them the first version of the extension was given birth and now [the Conan team is supporting it and pusing it
+forward](https://blog.conan.io/2019/06/17/Conan-extension-for-Visual-Studio.html). We still receive very valuable
+contributions from the community and we hope to continue to receive them.
 
-Update 02-06-2019
-------------------
-Plugin development is now being resumed after being stagnant for the past year. 
-
-The overall goal of the extension is for Visual Studio to be able to execute Conan automatically as-needed based on the currently loaded solution/project/configuration.  Over time, this could grow to a lot of convenience operations.  However, the primary (first) objective is to run `conan install` which will generate `conanbuildinfo.props` and satisfy the dependencies. 
-
-Thus, the first requirement is to provide users a mechanism for mapping each Solution/Project/Configuration to a corresponding `conan install` command. A strategy has been chosen for this, and is being discussed here: https://github.com/conan-io/conan-vs-extension/issues/5
-
-Overall, future features and should try to use a similar configuration-file-based strategy to provide maximum configurability and flexibility to the user of the extension, by making any new conan-related-operations exposed in any toolbar menus and right-click menus configurable and composeable.  This is particular important in the near-term while we are still deciding how the parts should work together, so that new workflow ideas can be tested without requiring code changes and rebuilds of the extension. 
-
+Each version and the released features are summarized in the
+[CHANGELOG file](https://github.com/conan-io/conan-vs-extension/tree/master/CHANGELOG.md). Feel free to
+request new features and follow the evolution of incoming ones in the issues and pull requests of this repository.

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,7 +58,7 @@ until the root one.
 Under the `"configurations"` key there is a dictionary with the correspondence between
 the Visual Studio configuration (key, on the left) and a Conan profile (value, on the right).
 
-It is important tto take into account:
+It is important to take into account:
  * Visual Studio creates the configuration name joining with a `|` character the name
    of the Configuration and the Platform.
  * For Conan profiles, the value declared will be used verbatim for the `--profile` argument

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,65 @@
 # Conan Extension for Visual Studio
 
+Conan Extension for Visual Studio provides a transparent integration between a Visual Studio
+project and the [Conan C/C++ package manager](https://docs.conan.io/en/latest/index.html). It
+automates the retrieval of Conan dependencies matching the configuration of the Visual Studio
+project and add the required include directories, linker ones and libraries.
+
+This extension uses under the hood one of the `visual_studio` generators that Conan provides,
+these generators create a _Visual Studio project properties_, the extension includes them
+in the corresponding project automatically, so the project has all the information needed
+to compile. Read more about these generators in the
+[Conan documentation](https://docs.conan.io/en/latest/integrations/build_system/msbuild.html#with-visual-studio-generator).
+
 ## Location of conanfile
+
+The extension works for every C++ project in the solution looking for a `conanfile.py` or
+`conanfile.txt` file in the directory tree. It starts to look for the file in the folder
+where the project is located and then moves up in the directory tree until the root
+directory looking for this file.
+
+Once found, it will trigger a [`conan install` command](https://docs.conan.io/en/latest/reference/commands/consumer/install.html)
+for the requirements declared in that file using the configuration that matches the
+current Visual Studio one (see below).
 
 ## Conan configuration
 
+A C++ project requires that all the libraries linked together are compiled using a
+compatible configuration, retrieving the proper binaries is one of the key value
+propositions of Conan as a package manager for C++.
+
+By default the extension is going to install the binaries using the configuration
+autodetected from the Visual Studio project properties. The extension will retrieve the
+third party binaries matching architecture, build type and some compiler characteristics
+like toolset, version and runtime.
+
+### conan.config
+Nevertheless, if you want more fine-grained control over the configuration used by
+Conan, you can provide a file with the pairing between the Visual Studio configuration
+names and the [Conan profiles](https://docs.conan.io/en/latest/reference/profiles.html).
+
+The file has to be called `conan.config.json`, and the lookup strategy that the Conan extension
+uses to find this file is the same as the one used for the `conanfile.py`: it will start
+in the folder where the project file is and then walk recursively to parent directories
+until the root one.
+
+ The file may contain the following information:
+
+```json
+{  
+   "configurations": {  
+      "Release|Win32": "release_win32",
+      "Debug|x64": "debug_x64",
+      "Release|Win64": "C:/conan/profiles/release_win64"
+   }
+}
+```
+
+Under the `"configurations"` key there is a dictionary with the correspondence between
+the Visual Studio configuration (key, on the left) and a Conan profile (value, on the right).
+
+It is important tto take into account:
+ * Visual Studio creates the configuration name joining with a `|` character the name
+   of the Configuration and the Platform.
+ * For Conan profiles, the value declared will be used verbatim for the `--profile` argument
+   in the `conan install` command, and rules related to profile lookup applies.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+# Conan Extension for Visual Studio
+
+## Location of conanfile
+
+## Conan configuration
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 Conan Extension for Visual Studio provides a transparent integration between a Visual Studio
 project and the [Conan C/C++ package manager](https://docs.conan.io/en/latest/index.html). It
 automates the retrieval of Conan dependencies matching the configuration of the Visual Studio
-project and add the required include directories, linker ones and libraries.
+project and adds the required include directories, linker ones and libraries.
 
 This extension uses under the hood one of the `visual_studio` generators that Conan provides,
 these generators create a _Visual Studio project properties_, the extension includes them


### PR DESCRIPTION
Add docs for #100 
related #99 

This PR adds very basic docs in a `docs` folder at the root of the repository. Also modifies the `README.md` file pointing to it and removing some information that could be outdated.