### PR TITLE
Capture errors from Conan and log them to output window and log file

### DIFF
--- a/Conan.VisualStudio.Core/ConanRunner.cs
+++ b/Conan.VisualStudio.Core/ConanRunner.cs
@@ -19,7 +19,7 @@ namespace Conan.VisualStudio.Core
         private string Escape(string arg) =>
             arg.Contains(" ") ? $"\"{arg}\"" : arg;
 
-        public Task<Process> Install(ConanProject project, ConanConfiguration configuration, ConanGeneratorType generator, ConanBuildType build, bool update, Core.IErrorListService errorListService)
+        public ProcessStartInfo Install(ConanProject project, ConanConfiguration configuration, ConanGeneratorType generator, ConanBuildType build, bool update, Core.IErrorListService errorListService)
         {
             string ProcessArgument(string name, string value) => $"-s {name}={Escape(value)}";
 
@@ -94,9 +94,11 @@ namespace Conan.VisualStudio.Core
                 UseShellExecute = false,
                 WorkingDirectory = Path.GetDirectoryName(project.Path),
                 RedirectStandardOutput = true,
+                RedirectStandardError = true,
                 CreateNoWindow = true
             };
-            return Task.Run(() => Process.Start(startInfo));
+            return startInfo;
+            //return Task.Run(() => Process.Start(startInfo));
         }
 
         public Task<Process> Inspect(ConanProject project)

--- a/Conan.VisualStudio.Core/ConanRunner.cs
+++ b/Conan.VisualStudio.Core/ConanRunner.cs
@@ -98,7 +98,6 @@ namespace Conan.VisualStudio.Core
                 CreateNoWindow = true
             };
             return startInfo;
-            //return Task.Run(() => Process.Start(startInfo));
         }
 
         public Task<Process> Inspect(ConanProject project)


### PR DESCRIPTION
Capture the errors from Conan output and log them to all available windows.

It also modifies the return type from ConanRunner, probably it is better to return just the `ProcessStartInfo` and let the consumer decide to run the command synchronously or not.

closes #118