### PR TITLE
Capture any unhandled error during install command

### DIFF
--- a/Conan.VisualStudio.Tests/Core/ConanPathHelperTests.cs
+++ b/Conan.VisualStudio.Tests/Core/ConanPathHelperTests.cs
@@ -24,7 +24,7 @@ namespace Conan.VisualStudio.Tests.Core
         {
             var directory = FileSystemUtils.CreateTempDirectory();
             const string extension = ".cmd";
-            var conanShim = FileSystemUtils.CreateTempFile(directory, "conan" + extension);
+            var conanShim = FileSystemUtils.CreateTempFile(directory, "conan" + extension, "exit 0");
 
             Environment.SetEnvironmentVariable("PATH", directory);
             Environment.SetEnvironmentVariable("PATHEXT", extension);
@@ -36,16 +36,16 @@ namespace Conan.VisualStudio.Tests.Core
         public void PathDeterminerRespectPathExtOrder()
         {
             var directory = FileSystemUtils.CreateTempDirectory();
-            var comShim = FileSystemUtils.CreateTempFile(directory, "conan.com");
+            var comShim = FileSystemUtils.CreateTempFile(directory, "conan.cmd", "exit 0");
             FileSystemUtils.CreateTempFile(directory, "conan.exe");
-            var batShim = FileSystemUtils.CreateTempFile(directory, "conan.bat");
+            var batShim = FileSystemUtils.CreateTempFile(directory, "conan.bat", "exit 0");
 
             Environment.SetEnvironmentVariable("PATH", directory);
 
-            Environment.SetEnvironmentVariable("PATHEXT", ".COM;.EXE;.BAT");
+            Environment.SetEnvironmentVariable("PATHEXT", ".CMD;.EXE;.BAT");
             Assert.AreEqual(comShim, ConanPathHelper.DetermineConanPathFromEnvironment());
 
-            Environment.SetEnvironmentVariable("PATHEXT", ".BAT;.EXE;.COM");
+            Environment.SetEnvironmentVariable("PATHEXT", ".BAT;.EXE;.CMD");
             Assert.AreEqual(batShim, ConanPathHelper.DetermineConanPathFromEnvironment());
         }
 

--- a/Conan.VisualStudio.Tests/FileSystemUtils.cs
+++ b/Conan.VisualStudio.Tests/FileSystemUtils.cs
@@ -14,10 +14,13 @@ namespace Conan.VisualStudio.Tests
             return path;
         }
 
-        public static string CreateTempFile(string directory, string name)
+        public static string CreateTempFile(string directory, string name, string contents = "")
         {
             var path = Path.Combine(directory, name);
-            File.Create(path).Close();
+            FileStream f = File.Create(path);
+            byte[] info = new UTF8Encoding(true).GetBytes(contents);
+            f.Write(info, 0, info.Length);
+            f.Close();
             return path;
         }
 

--- a/Conan.VisualStudio/ConanOptionsPage.cs
+++ b/Conan.VisualStudio/ConanOptionsPage.cs
@@ -1,4 +1,6 @@
+using System;
 using System.ComponentModel;
+using System.Windows.Forms;
 using Conan.VisualStudio.Core;
 using Microsoft.VisualStudio.Shell;
 
@@ -13,6 +15,29 @@ namespace Conan.VisualStudio
         private bool? _conanInstallAutomatically;
         private ConanBuildType? _conanBuild;
         private bool? _conanUpdate;
+
+        protected override void OnApply(PageApplyEventArgs e)
+        {
+            if (!ValidateConanExecutableAndShowMessage(_conanExecutablePath))
+            {
+                e.ApplyBehavior = ApplyKind.Cancel;
+            }
+            else
+            {
+                base.OnApply(e);
+            }
+        }
+
+        private bool ValidateConanExecutableAndShowMessage(string exe)
+        {
+            if (!ConanPathHelper.ValidateConanExecutable(exe, out string errorMessage))
+            {
+                MessageBox.Show(errorMessage, "Conan extension: invalid conan executable",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return false;
+            }
+            return true;
+        }
 
         [Category("Conan")]
         [DisplayName("Conan executable")]

--- a/Conan.VisualStudio/Menu/AddConanDependsProject.cs
+++ b/Conan.VisualStudio/Menu/AddConanDependsProject.cs
@@ -34,8 +34,11 @@ namespace Conan.VisualStudio.Menu
                 return;
             }
 
-            await _conanService.InstallAsync(vcProject);
-            await _conanService.IntegrateAsync(vcProject);
+            bool success = await _conanService.InstallAsync(vcProject);
+            if (success)
+            {
+                await _conanService.IntegrateAsync(vcProject);
+            }
         }
     }
 }

--- a/Conan.VisualStudio/Menu/AddConanDependsSolution.cs
+++ b/Conan.VisualStudio/Menu/AddConanDependsSolution.cs
@@ -41,8 +41,11 @@ namespace Conan.VisualStudio.Menu
             {
                 if (_vcProjectService.IsConanProject(project))
                 {
-                    await _conanService.InstallAsync(_vcProjectService.AsVCProject(project));
-                    await _conanService.IntegrateAsync(_vcProjectService.AsVCProject(project));
+                    bool success = await _conanService.InstallAsync(_vcProjectService.AsVCProject(project));
+                    if (success)
+                    {
+                        await _conanService.IntegrateAsync(_vcProjectService.AsVCProject(project));
+                    }
                 }
             }
             await TaskScheduler.Default;

--- a/Conan.VisualStudio/Services/ConanService.cs
+++ b/Conan.VisualStudio/Services/ConanService.cs
@@ -185,9 +185,10 @@ namespace Conan.VisualStudio.Services
                             }
                         }
                     }
-                    catch(System.ComponentModel.Win32Exception)
+                    catch(System.ComponentModel.Win32Exception e)
                     {
-                        message = $"[Conan.VisualStudio] Error running '{process.FileName}'. Is it a valid path to conan.exe?";
+                        message = $"[Conan.VisualStudio] Unhandled error running '{process.FileName}'" +
+                                  $": {e.Message}. Check the executable path and also the output in '{logFilePath}'";
                         Logger.Log(message);
                         await logStream.WriteLineAsync(message);
                         _errorListService.WriteError(message);

--- a/Conan.VisualStudio/Services/ConanService.cs
+++ b/Conan.VisualStudio/Services/ConanService.cs
@@ -141,6 +141,8 @@ namespace Conan.VisualStudio.Services
                     ConanBuildType build = _settingsService.GetConanBuild();
                     bool update = _settingsService.GetConanUpdate();
 
+                    ProcessStartInfo process = conan.Install(project, configuration, generator, build, update, _errorListService);
+
                     string message = $"[Conan.VisualStudio] Calling process '{process.FileName}' " +
                                      $"with arguments '{process.Arguments}'";
                     Logger.Log(message);
@@ -188,7 +190,7 @@ namespace Conan.VisualStudio.Services
                     catch(System.ComponentModel.Win32Exception e)
                     {
                         message = $"[Conan.VisualStudio] Unhandled error running '{process.FileName}'" +
-                                  $": {e.Message}. Check the executable path and also the output in '{logFilePath}'";
+                                  $": {e.Message}. Check log file '{logFilePath}' for details";
                         Logger.Log(message);
                         await logStream.WriteLineAsync(message);
                         _errorListService.WriteError(message);

--- a/Conan.VisualStudio/Services/IConanService.cs
+++ b/Conan.VisualStudio/Services/IConanService.cs
@@ -11,6 +11,6 @@ namespace Conan.VisualStudio.Services
     {
         Task IntegrateAsync(VCProject vcProject);
 
-        Task InstallAsync(VCProject vcProject);
+        Task<bool> InstallAsync(VCProject vcProject);
     }
 }

--- a/Conan.VisualStudio/VSConanPackage.cs
+++ b/Conan.VisualStudio/VSConanPackage.cs
@@ -186,8 +186,11 @@ namespace Conan.VisualStudio
             ThreadHelper.JoinableTaskFactory.RunAsync(
                 async delegate
                 {
-                    await _conanService.InstallAsync(vcProject);
-                    await _conanService.IntegrateAsync(vcProject);
+                    bool success = await _conanService.InstallAsync(vcProject);
+                    if (success)
+                    {
+                        await _conanService.IntegrateAsync(vcProject);
+                    }
                 }
             );
         }


### PR DESCRIPTION
on top of #125 

This is capturing the kind of error we get when the path to Conan is ill-formed. Related to #117 but doesn't close it as it is not checking the path at the moment the user modifies it.