### PR TITLE
- remove no longer used VcProjectService methods [skip changelog]

### DIFF
--- a/Conan.VisualStudio/Services/IVcProjectService.cs
+++ b/Conan.VisualStudio/Services/IVcProjectService.cs
@@ -11,9 +11,6 @@ namespace Conan.VisualStudio.Services
         VCProject GetActiveProject();
         ConanProject ExtractConanProject(VCProject vcProject, ISettingsService settingsService);
         Task<ConanProject> ExtractConanProjectAsync(VCProject vcProject, ISettingsService settingsService);
-        Task AddPropsImportAsync(string projectPath, string propFilePath);
-        Guid UnloadProject(VCProject project);
-        void ReloadProject(Guid projectGuid);
         bool IsConanProject(Project project);
         VCProject AsVCProject(Project project);
         string GetInstallationDirectory(ISettingsService settingsService, VCConfiguration configuration);

--- a/Conan.VisualStudio/Services/InfoBarEventsHandler.cs
+++ b/Conan.VisualStudio/Services/InfoBarEventsHandler.cs
@@ -22,8 +22,8 @@ namespace Conan.VisualStudio.Services
 
         public void OnActionItemClicked(IVsInfoBarUIElement infoBarUIElement, IVsInfoBarActionItem actionItem)
         {
-            var projectGuid = _vcProjectService.UnloadProject(_project);
-            _vcProjectService.ReloadProject(projectGuid);
+            //var projectGuid = _vcProjectService.UnloadProject(_project);
+            //_vcProjectService.ReloadProject(projectGuid);
             ThreadHelper.ThrowIfNotOnUIThread();
             infoBarUIElement.Close();
         }

--- a/Conan.VisualStudio/Services/InfoBarEventsHandler.cs
+++ b/Conan.VisualStudio/Services/InfoBarEventsHandler.cs
@@ -22,8 +22,6 @@ namespace Conan.VisualStudio.Services
 
         public void OnActionItemClicked(IVsInfoBarUIElement infoBarUIElement, IVsInfoBarActionItem actionItem)
         {
-            //var projectGuid = _vcProjectService.UnloadProject(_project);
-            //_vcProjectService.ReloadProject(projectGuid);
             ThreadHelper.ThrowIfNotOnUIThread();
             infoBarUIElement.Close();
         }

--- a/Conan.VisualStudio/Services/VcProjectService.cs
+++ b/Conan.VisualStudio/Services/VcProjectService.cs
@@ -169,53 +169,5 @@ namespace Conan.VisualStudio.Services
                 RuntimeLibrary = VCCLCompilerTool != null ? RuntimeLibraryToString(VCCLCompilerTool.RuntimeLibrary) : null
             };
         }
-
-        public Task AddPropsImportAsync(string projectPath, string propFilePath) => Task.Run(() =>
-        {
-            var xml = XDocument.Load(projectPath);
-            var project = xml.Root;
-            if (project == null)
-            {
-                throw new Exception($"Project {projectPath} is malformed: no root element");
-            }
-
-            XNamespace ns = "http://schemas.microsoft.com/developer/msbuild/2003";
-            var import = ns + "Import";
-            var existingImports = project.Descendants(import);
-            if (existingImports.Any(node => node.Attribute("Project")?.Value == propFilePath))
-            {
-                return;
-            }
-
-            var newImport = new XElement(import);
-            newImport.SetAttributeValue("Project", propFilePath);
-            newImport.SetAttributeValue("Condition", $"Exists('{propFilePath}')");
-            project.Add(newImport);
-
-            xml.Save(projectPath);
-        });
-
-        public Guid UnloadProject(VCProject project)
-        {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
-            var projectGuid = new Guid(project.ProjectGUID);
-            var solution = Package.GetGlobalService(typeof(SVsSolution)) as IVsSolution4;
-
-            int hr = solution.UnloadProject(ref projectGuid, (uint)_VSProjectUnloadStatus.UNLOADSTATUS_UnloadedByUser);
-            ErrorHandler.ThrowOnFailure(hr);
-
-            return projectGuid;
-        }
-
-        public void ReloadProject(Guid projectGuid)
-        {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
-            var solution = Package.GetGlobalService(typeof(SVsSolution)) as IVsSolution4;
-
-            int hr = solution.ReloadProject(ref projectGuid);
-            ErrorHandler.ThrowOnFailure(hr);
-        }
     }
 }


### PR DESCRIPTION
related: https://github.com/conan-io/conan-vs-extension/issues/113

* AddPropsImportAsync
* UnloadProject
* ReloadProject
