### PR TITLE
Add all available options for 'build_policy' according to Conan documentation

### DIFF
--- a/Conan.VisualStudio.Core/ConanSettings.cs
+++ b/Conan.VisualStudio.Core/ConanSettings.cs
@@ -21,9 +21,11 @@ namespace Conan.VisualStudio.Core
 
     public enum ConanBuildType
     {
-        none,
-        missing,
         always,
-        outdated
+        never,
+        missing,
+        cascade,
+        outdated,
+        none
     }
 }

--- a/Conan.VisualStudio/ConanOptionsPage.cs
+++ b/Conan.VisualStudio/ConanOptionsPage.cs
@@ -86,7 +86,7 @@ namespace Conan.VisualStudio
 
         [Category("Conan")]
         [DisplayName("Build policy")]
-        [Description(@"--build argument (missing, outdated, always or none)")]
+        [Description(@"--build argument (always, never, missing, cascade, outdated or none)")]
         public ConanBuildType ConanBuild
         {
             get => _conanBuild ?? ConanBuildType.missing;


### PR DESCRIPTION
closes #141 
- `always` resolves just to `--build` (instead of `--build always`)
- use `--build=<policy>` instead of `--build policy`
- add `cascade`
- extract method to avoid code duplication