### PR TITLE
Add menu option 'About' to show all information about the extension

### DIFF
--- a/Conan.VisualStudio/Conan.VisualStudio.csproj
+++ b/Conan.VisualStudio/Conan.VisualStudio.csproj
@@ -76,6 +76,7 @@
     <Compile Include="ConanOptionsPage.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="Menu\ConanAbout.cs" />
     <Compile Include="Menu\ConanOptions.cs" />
     <Compile Include="Menu\MenuCommandBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Conan.VisualStudio/Menu/ConanAbout.cs
+++ b/Conan.VisualStudio/Menu/ConanAbout.cs
@@ -1,0 +1,39 @@
+using System;
+using System.ComponentModel.Design;
+using System.Diagnostics;
+using System.Reflection;
+using System.Windows.Forms;
+using Conan.VisualStudio.Services;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+namespace Conan.VisualStudio.Menu
+{
+    /// <summary>Command handler.</summary>
+    internal sealed class ConanAbout : MenuCommandBase
+    {
+        protected override int CommandId => PackageIds.ConanAboutId;
+
+        public ConanAbout(
+            IMenuCommandService commandService,
+            Core.IErrorListService errorListService)
+            : base(commandService, errorListService)
+        {
+            
+        }
+
+        protected internal override async Task MenuItemCallbackAsync()
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            var assembly = Assembly.GetExecutingAssembly();
+            string version = assembly.GetName().Version.ToString();
+            string fileVersionInfo = assembly.GetCustomAttribute<AssemblyDescriptionAttribute>().Description.ToString();
+            Logger.Log($"About Conan Extension for Visual Studio: {version} ({fileVersionInfo})");
+
+            string message = String.Format("Conan Extension for Visual Studio\n" +
+                $"Version\t: {version}\n" +
+                $"Commit\t: {fileVersionInfo}");
+            MessageBox.Show(message, "About Conan Extension", MessageBoxButtons.OK);
+        }
+    }
+}

--- a/Conan.VisualStudio/Properties/AssemblyInfo.cs
+++ b/Conan.VisualStudio/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("Conan.VisualStudio")]
-[assembly: AssemblyDescription("Conan extension for Visual Studio")]
+[assembly: AssemblyDescription("<git-sha>")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("JFrog LTD")]
 [assembly: AssemblyProduct("Conan.VisualStudio")]

--- a/Conan.VisualStudio/VSConan.cs
+++ b/Conan.VisualStudio/VSConan.cs
@@ -29,6 +29,7 @@ namespace Conan.VisualStudio
         public const int AddConanDependsProjectId = 0x0100;
         public const int AddConanDependsSolutiontId = 0x0101;
         public const int ConanOptionsId = 0x0103;
+        public const int ConanAboutId = 0x0104;
         public const int ConanSubmenu = 0x1023;
         public const int ConanSubmenuGroup = 0x1024;
         public const int ConanProjectGroup = 0x1025;

--- a/Conan.VisualStudio/VSConan.vsct
+++ b/Conan.VisualStudio/VSConan.vsct
@@ -62,6 +62,13 @@
                     <ButtonText>Options...</ButtonText>
                 </Strings>
             </Button>
+            <Button guid="guidVSConanPackageCmdSet" id="ConanAboutId" priority="0x0100" type="Button">
+                <Parent guid="guidVSConanPackageCmdSet" id="ConanSubmenuGroup" />
+                <Icon guid="guidImages" id="conanIcon" />
+                <Strings>
+                    <ButtonText>About</ButtonText>
+                </Strings>
+            </Button>
         </Buttons>
 
         <Bitmaps>
@@ -93,6 +100,7 @@
             <IDSymbol name="AddConanDependsProjectId" value="0x0100" />
             <IDSymbol name="AddConanDependsSolutiontId" value="0x0101" />
             <IDSymbol name="ConanOptionsId" value="0x0103" />
+            <IDSymbol name="ConanAboutId" value="0x0104" />
             <IDSymbol name="ConanSubmenu" value="4131" />
             <IDSymbol name="ConanSubmenuGroup" value="4132" />
             <IDSymbol name="ConanProjectGroup" value="4133"/>

--- a/Conan.VisualStudio/VSConanPackage.cs
+++ b/Conan.VisualStudio/VSConanPackage.cs
@@ -35,6 +35,7 @@ namespace Conan.VisualStudio
         private AddConanDependsProject _addConanDependsProject;
         private AddConanDependsSolution _addConanDependsSolution;
         private ConanOptions _conanOptions;
+        private ConanAbout _conanAbout;
         private DTE _dte;
         private SolutionEvents _solutionEvents;
         private IVsSolution _solution;
@@ -82,6 +83,7 @@ namespace Conan.VisualStudio
             _addConanDependsSolution = new AddConanDependsSolution(commandService, _errorListService, _vcProjectService,  _conanService);
 
             _conanOptions = new ConanOptions(commandService, _errorListService, ShowOptionPage);
+            _conanAbout = new ConanAbout(commandService, _errorListService);
 
             await TaskScheduler.Default;
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ for:
       - ps: Vsix-TokenReplacement Conan.VisualStudio\Properties\AssemblyInfo.cs '"1.0.0.0"' '"{version}"'
       - ps: Vsix-TokenReplacement Conan.VisualStudio.Core\Properties\AssemblyInfo.cs '"1.0.0.0"' '"{version}"'
       - ps: Vsix-TokenReplacement Conan.VisualStudio.Tests\Properties\AssemblyInfo.cs '"1.0.0.0"' '"{version}"'
-      - ps: Vsix-TokenReplacement Conan.VisualStudio\Properties\AssemblyInfo.cs '<git-sha>' '$env:APPVEYOR_REPO_COMMIT'
+      - ps: Vsix-TokenReplacement Conan.VisualStudio\Properties\AssemblyInfo.cs '<git-sha>' $env:APPVEYOR_REPO_COMMIT
       - nuget restore
     build_script:
       - msbuild /p:DeployExtension=false /p:verbosity=detailed

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,7 @@ for:
       - ps: Vsix-TokenReplacement Conan.VisualStudio\Properties\AssemblyInfo.cs '"1.0.0.0"' '"{version}"'
       - ps: Vsix-TokenReplacement Conan.VisualStudio.Core\Properties\AssemblyInfo.cs '"1.0.0.0"' '"{version}"'
       - ps: Vsix-TokenReplacement Conan.VisualStudio.Tests\Properties\AssemblyInfo.cs '"1.0.0.0"' '"{version}"'
+      - ps: Vsix-TokenReplacement Conan.VisualStudio\Properties\AssemblyInfo.cs '<git-sha>' '$env:APPVEYOR_REPO_COMMIT'
       - nuget restore
     build_script:
       - msbuild /p:DeployExtension=false /p:verbosity=detailed


### PR DESCRIPTION
Having this information available will be very important for error reports if we need to ask for more information to the user.

The functionality is there, although the UI... we need a new label for UI related issues, just in case anyone wants to help us 😄 

---
![image](https://user-images.githubusercontent.com/1406456/62380047-9d217880-b548-11e9-8f78-510e9c871c02.png)
---
![image](https://user-images.githubusercontent.com/1406456/62380062-a7437700-b548-11e9-9eef-2c63148e7d9d.png)
---
closes #150 