### PR TITLE
remove VisualStudioVersion from the environment variables

### DIFF
--- a/Conan.VisualStudio.Core/ConanRunner.cs
+++ b/Conan.VisualStudio.Core/ConanRunner.cs
@@ -101,7 +101,7 @@ namespace Conan.VisualStudio.Core
                 RedirectStandardError = true,
                 CreateNoWindow = true
             };
-            startInfo.EnvironmentVariables.Remove("VisualStudioVersion");
+            startInfo.EnvironmentVariables.Remove("VisualStudioVersion");  // FIXME: Hack for https://github.com/conan-io/conan/issues/5580
             return startInfo;
         }
     }

--- a/Conan.VisualStudio.Core/ConanRunner.cs
+++ b/Conan.VisualStudio.Core/ConanRunner.cs
@@ -101,6 +101,7 @@ namespace Conan.VisualStudio.Core
                 RedirectStandardError = true,
                 CreateNoWindow = true
             };
+            startInfo.EnvironmentVariables.Remove("VisualStudioVersion");
             return startInfo;
         }
     }


### PR DESCRIPTION
closes #153

remove `VisualStudioVersion` from the environment variables before starting the conan process.
therefore, conan will set correct `vcvars`, and things like `nmake` will be available for the build.
this needs to be addressed in conan, but:
1. it will take time until it's fixed and new release is available
2. many enterprise users don't update and stick to the specific conan versions